### PR TITLE
Add open image feature

### DIFF
--- a/fzf.go
+++ b/fzf.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -38,28 +39,81 @@ func SelectCommandWithFzf(commands []CommandMeta) (string, error) {
 // SelectFileWithFzf launches fzf with a list of common image files found under startDir.
 // It returns the full path of the selected file or an error if selection failed.
 //
+// This implementation reuses the terminal detection helpers in terminal_preview.go
+// (isKitty, isInlineImageCapable, isSixelCapable, PreviewSupported) to choose a
+// reasonable --preview command for fzf. The preview will attempt to use the most
+// capable renderer available for the detected terminal.
+//
 // Note: This implementation shells out to `find` piped into `fzf`. It requires both
 // `find` and `fzf` to be available in PATH. startDir may be "." or any directory path.
 func SelectFileWithFzf(startDir string) (string, error) {
 	// Quote the directory to safely handle spaces/special chars.
 	quotedDir := strconv.Quote(startDir)
 
-	// Build a shell pipeline that finds image files and feeds them into fzf.
-	// The percent sign in the format string is escaped as %%.
-	cmdStr := fmt.Sprintf("find %s -type f \\( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' -o -iname '*.gif' -o -iname '*.tif' -o -iname '*.tiff' \\) | fzf --height 40%% --border --prompt='Files> '", quotedDir)
+	// Build a terminal-aware preview command for fzf. The preview command uses
+	// fzf's {} replacement for the current file path. We prefer inline/kitty/sixel
+	// renderers when the terminal detection indicates support; otherwise fall back
+	// to `chafa` for pixelated rendering or textual preview.
+	//
+	// The preview command tries multiple renderers in order, using `||` to fall
+	// back if the preferred renderer is not available. Errors are redirected to
+	// /dev/null to avoid cluttering the preview pane.
+	//
+	// Note: fzf's --preview option does not support complex shell constructs like
+	// conditionals or functions, so we must use a single command line with `||`
+	// chains to achieve fallback behavior.
+	//
+	// We also include a control sequence to clear kitty images before rendering
+	// a new image, to avoid accumulating images in the terminal buffer.
+	var previewCmd string
 
+	// Helper chains: try best renderer, then fall back to others or textual viewers.
+	if isKitty() {
+		// Prefer kitty icat. If unavailable, try chafa.
+		previewCmd = "printf \"\\x1b_Ga=d\\x1b\\\\\"; kitty +kitten icat --silent {} 2>/dev/null || chafa --fill=block --symbols=block -s 80x40 {} 2>/dev/null"
+	} else if isInlineImageCapable() {
+		// Prefer imgcat (iTerm2 integration). If not present, try chafa.
+		previewCmd = "imgcat {} 2>/dev/null  || chafa --fill=block --symbols=block -s 80x40 {} 2>/dev/null"
+	} else if isSixelCapable() {
+		// Prefer sixel renderers. If img2sixel not present, try chafa.
+		previewCmd = "img2sixel {} 2>/dev/null || chafa --fill=block --symbols=block -s 80x40 {} 2>/dev/null"
+	} else {
+		// No detected image-capable terminal: use pixel renderer if present, else textual preview.
+		previewCmd = "chafa --fill=block --symbols=block -s 80x40 {} 2>/dev/null"
+	}
+
+	// Build the find + fzf command. Escape percent signs in the format string.
+	// Use --preview-window to allocate space on the right for the preview.
+	cmdStr := fmt.Sprintf(
+		"find %s -type f \\( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' -o -iname '*.gif' -o -iname '*.tif' -o -iname '*.tiff' \\) | fzf --height 100%% --border --prompt='Files> ' --ansi --preview=%q --preview-window='right:60%%'",
+		quotedDir,
+		previewCmd,
+	)
 	cmd := exec.Command("bash", "-lc", cmdStr)
 
 	var out bytes.Buffer
 	cmd.Stdout = &out
 
 	if err := cmd.Run(); err != nil {
+		// attempt to clear kitty images regardless of error
+		clearKittyImages()
 		return "", fmt.Errorf("error running fzf for files: %w", err)
 	}
+
+	// clear preview images left behind by the previewer (kitty graphics)
+	clearKittyImages()
 
 	selection := strings.TrimSpace(out.String())
 	if selection == "" {
 		return "", fmt.Errorf("no file selected")
 	}
 	return selection, nil
+}
+
+// clearKittyImages emits the kitty graphics "delete" control sequence.
+// Terminals that don't understand it will ignore it.
+func clearKittyImages() {
+	// ESC _ G a=d ESC \
+	// We write to stdout so the control sequence targets the foreground terminal.
+	fmt.Fprint(os.Stdout, "\x1b_Ga=d\x1b\\")
 }

--- a/fzf.go
+++ b/fzf.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -32,4 +33,33 @@ func SelectCommandWithFzf(commands []CommandMeta) (string, error) {
 	}
 
 	return "", fmt.Errorf("no command selected")
+}
+
+// SelectFileWithFzf launches fzf with a list of common image files found under startDir.
+// It returns the full path of the selected file or an error if selection failed.
+//
+// Note: This implementation shells out to `find` piped into `fzf`. It requires both
+// `find` and `fzf` to be available in PATH. startDir may be "." or any directory path.
+func SelectFileWithFzf(startDir string) (string, error) {
+	// Quote the directory to safely handle spaces/special chars.
+	quotedDir := strconv.Quote(startDir)
+
+	// Build a shell pipeline that finds image files and feeds them into fzf.
+	// The percent sign in the format string is escaped as %%.
+	cmdStr := fmt.Sprintf("find %s -type f \\( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' -o -iname '*.gif' -o -iname '*.tif' -o -iname '*.tiff' \\) | fzf --height 40%% --border --prompt='Files> '", quotedDir)
+
+	cmd := exec.Command("bash", "-lc", cmdStr)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("error running fzf for files: %w", err)
+	}
+
+	selection := strings.TrimSpace(out.String())
+	if selection == "" {
+		return "", fmt.Errorf("no file selected")
+	}
+	return selection, nil
 }

--- a/main.go
+++ b/main.go
@@ -166,12 +166,20 @@ func main() {
 			fmt.Printf("Saved to %s\n", out)
 
 		case 'o':
-			// Open another image at runtime. Read into a new wand and swap safely.
-			newPath, _ := promptLine("Enter path to image to open (leave empty to cancel): ")
-			if newPath == "" {
-				fmt.Println("open cancelled")
-				continue
+			// Open another image at runtime. Prefer fzf-based file selection; fall back to typed path.
+			selected, selErr := SelectFileWithFzf(".")
+			var newPath string
+			if selErr != nil || selected == "" {
+				// fzf failed, was cancelled, or returned nothing — fall back to a typed path prompt.
+				newPath, _ = promptLine("Enter path to image to open (leave empty to cancel): ")
+				if newPath == "" {
+					fmt.Println("open cancelled")
+					continue
+				}
+			} else {
+				newPath = selected
 			}
+
 			newWand := imagick.NewMagickWand()
 			if err := newWand.ReadImage(newPath); err != nil {
 				fmt.Fprintf(os.Stderr, "failed to read image %s: %v\n", newPath, err)

--- a/terminal_preview.go
+++ b/terminal_preview.go
@@ -27,6 +27,10 @@ import (
 //     the kitty graphics protocol (chunked base64 inside ESC _G ... ESC \).
 //   - Else if iTerm2 is detected (TERM_PROGRAM == "iTerm.app" || ITERM_SESSION_ID present),
 //     the PNG is sent using the iTerm2 OSC 1337 inline file sequence.
+//   - Else if other terminals known to support inline images (WezTerm, Warp, Tabby, VSCode, etc)
+//     the same iTerm2-style OSC 1337 sequence is used.
+//   - Else if a terminal likely to support Sixel graphics is detected (foot, Windows Terminal, st with sixel patch, etc),
+//     the PNG is piped to an external sixel renderer (img2sixel or chafa).
 //   - If neither is detected, PreviewWand returns an error indicating no supported terminal.
 //
 // Notes:

--- a/terminal_preview.go
+++ b/terminal_preview.go
@@ -31,7 +31,9 @@ import (
 //     the same iTerm2-style OSC 1337 sequence is used.
 //   - Else if a terminal likely to support Sixel graphics is detected (foot, Windows Terminal, st with sixel patch, etc),
 //     the PNG is piped to an external sixel renderer (img2sixel or chafa).
-//   - If neither is detected, PreviewWand returns an error indicating no supported terminal.
+//   - Else, if chafa is available on PATH, it will be invoked to render a terminal-friendly approximation
+//     even for terminals that don't implement the above protocols.
+//   - If none is available, PreviewWand returns an error indicating no supported terminal.
 //
 // Notes:
 //   - The function clones the provided wand to set the image format to PNG without mutating
@@ -78,7 +80,7 @@ func isKitty() bool {
 	return false
 }
 
-// Detects terminals that implement the generic \"inline images\" OSC protocol
+// Detects terminals that implement the generic "inline images" OSC protocol
 // (iTerm2 style) — many modern terminal emulators (WezTerm, Warp, Tabby, VSCode's terminal,
 // Rio, Hyper, Bobcat and others) implement that or compatible behavior.
 // We use a heuristic based on TERM_PROGRAM and common TERM substrings.
@@ -121,15 +123,29 @@ func isSixelCapable() bool {
 	return false
 }
 
+// hasChafa reports whether the external 'chafa' binary is available in PATH.
+// We treat chafa as a usable fallback for terminals that don't implement inline
+// or sixel protocols but can still display block/character graphics.
+func hasChafa() bool {
+	if os.Getenv("CHAFAPREVIEW") == "1" {
+		return true
+	}
+	if _, err := exec.LookPath("chafa"); err == nil {
+		return true
+	}
+	return false
+}
+
 // PreviewSupported returns true if the running environment likely supports a terminal inline preview.
+// We consider chafa availability as a valid fallback even if no inline/sixel protocol is detected.
 func PreviewSupported() bool {
-	supported := isKitty() || isInlineImageCapable() || isSixelCapable()
-	debugf("PreviewSupported -> %v (kitty=%v inline=%v sixel=%v)", supported, isKitty(), isInlineImageCapable(), isSixelCapable())
+	supported := isKitty() || isInlineImageCapable() || isSixelCapable() || hasChafa()
+	debugf("PreviewSupported -> %v (kitty=%v inline=%v sixel=%v chafa=%v)", supported, isKitty(), isInlineImageCapable(), isSixelCapable(), hasChafa())
 	return supported
 }
 
 // PreviewWand takes a MagickWand and tries to display it inline in the terminal.
-// It prefers kitty unicode/graphics placement, then the inline images OSC, then Sixel.
+// It prefers kitty unicode/graphics placement, then the inline images OSC, then Sixel, then chafa.
 // Returns error if unsupported or on failure.
 func PreviewWand(wand *imagick.MagickWand) error {
 	if wand == nil {
@@ -137,7 +153,7 @@ func PreviewWand(wand *imagick.MagickWand) error {
 	}
 
 	// Log entry and detection state when debugging is enabled
-	debugf("PreviewWand called (supported=%v, KITTY=%v, INLINE=%v, SIXEL=%v)", PreviewSupported(), isKitty(), isInlineImageCapable(), isSixelCapable())
+	debugf("PreviewWand called (supported=%v, KITTY=%v, INLINE=%v, SIXEL=%v, CHAF A=%v)", PreviewSupported(), isKitty(), isInlineImageCapable(), isSixelCapable(), hasChafa())
 
 	if !PreviewSupported() {
 		return fmt.Errorf("no supported terminal preview protocol detected")
@@ -190,6 +206,16 @@ func PreviewWand(wand *imagick.MagickWand) error {
 					debugf("sixel also failed: %v", err3)
 				}
 			}
+			// fallback to chafa if available
+			if hasChafa() {
+				debugf("falling back to chafa rendering")
+				if err4 := sendChafaPNG(blob); err4 == nil {
+					debugf("chafa succeeded after kitty failure")
+					return nil
+				} else {
+					debugf("chafa also failed: %v", err4)
+				}
+			}
 			return fmt.Errorf("kitty preview failed: %w", err)
 		}
 		debugf("kitty protocol succeeded")
@@ -211,6 +237,16 @@ func PreviewWand(wand *imagick.MagickWand) error {
 					debugf("sixel also failed: %v", err2)
 				}
 			}
+			// fallback to chafa if available
+			if hasChafa() {
+				debugf("falling back to chafa rendering from inline image failure")
+				if err3 := sendChafaPNG(blob); err3 == nil {
+					debugf("chafa succeeded after inline image failure")
+					return nil
+				} else {
+					debugf("chafa also failed: %v", err3)
+				}
+			}
 			return fmt.Errorf("inline image preview failed: %w", err)
 		}
 		debugf("inline image OSC succeeded")
@@ -220,9 +256,30 @@ func PreviewWand(wand *imagick.MagickWand) error {
 	// Fallback: try Sixel-capable terminals
 	if isSixelCapable() {
 		if err := sendSixelPNG(blob); err != nil {
+			// If sixel rendering fails, but chafa is available, try chafa as a fallback.
+			if hasChafa() {
+				debugf("sixel failed; attempting chafa fallback")
+				if err2 := sendChafaPNG(blob); err2 == nil {
+					debugf("chafa fallback succeeded after sixel failure")
+					return nil
+				} else {
+					debugf("chafa fallback also failed: %v", err2)
+				}
+			}
 			return fmt.Errorf("sixel preview failed: %w", err)
 		}
 		return nil
+	}
+
+	// If chafa is available, try it even if no protocol heuristics matched.
+	if hasChafa() {
+		debugf("no protocol matched, but chafa detected; attempting chafa rendering")
+		if err := sendChafaPNG(blob); err == nil {
+			debugf("chafa rendering succeeded")
+			return nil
+		} else {
+			debugf("chafa rendering failed: %v", err)
+		}
 	}
 
 	return fmt.Errorf("no preview protocol matched")
@@ -371,11 +428,7 @@ func sendSixelPNG(data []byte) error {
 	}
 
 	// If img2sixel isn't available, try chafa as a fallback (chafa supports multiple terminals).
-	cmd = exec.Command("chafa", "--fill=block", "--symbols=block", "-s", "auto", "-")
-	cmd.Stdin = bytes.NewReader(data)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err == nil {
+	if err := sendChafaPNG(data); err == nil {
 		debugf("chafa succeeded")
 		// Ensure the cursor moves to the next line after the image.
 		for i := 0; i < 20; i++ {
@@ -399,4 +452,67 @@ func sendSixelPNG(data []byte) error {
 	}
 
 	return err
+}
+
+// sendChafaPNG invokes chafa to render the provided PNG bytes to stdout.
+// It attempts to choose reasonable flags to produce a block-symbol rendering that
+// works in many terminals. The function returns an error if chafa is not present or fails.
+func sendChafaPNG(data []byte) error {
+	if len(data) == 0 {
+		return fmt.Errorf("no data")
+	}
+
+	// Allow an environment override to skip attempting chafa when explicitly disabled.
+	if os.Getenv("NO_CHAFA") == "1" {
+		return fmt.Errorf("chafa usage disabled via NO_CHAFA=1")
+	}
+
+	// Ensure chafa exists
+	if _, err := exec.LookPath("chafa"); err != nil {
+		return fmt.Errorf("chafa not found in PATH: %w", err)
+	}
+
+	debugf("sendChafaPNG invoking chafa for %d bytes", len(data))
+
+	// Determine chafa args. Use block fill and symbols for dense output.
+	// Default size is 80x40; user can override via CHAFA_SIZE.
+	args := []string{"--fill=block", "--symbols=block", "-s", "80x40", "-"}
+
+	if v := os.Getenv("CHAFA_SIZE"); v != "" {
+		// If the user provides a size override, pass it through to -s.
+		args = []string{"--fill=block", "--symbols=block", "-s", v, "-"}
+	}
+
+	// Allow custom fill/symbol selection via env (optional)
+	if f := os.Getenv("CHAFA_FILL"); f != "" {
+		// replace --fill value
+		for i, a := range args {
+			if strings.HasPrefix(a, "--fill=") {
+				args[i] = "--fill=" + f
+			}
+		}
+	}
+	if s := os.Getenv("CHAFA_SYMBOLS"); s != "" {
+		for i, a := range args {
+			if strings.HasPrefix(a, "--symbols=") {
+				args[i] = "--symbols=" + s
+			}
+		}
+	}
+
+	cmd := exec.Command("chafa", args...)
+	cmd.Stdin = bytes.NewReader(data)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("chafa failed: %w", err)
+	}
+
+	// Ensure adequate spacing after the image so subsequent text isn't overwritten.
+	for i := 0; i < 20; i++ {
+		fmt.Println()
+	}
+
+	return nil
 }


### PR DESCRIPTION
This pull request adds a runtime "open image" feature and improves terminal image preview compatibility by introducing chafa as a fallback renderer. Users can now open new images interactively (with fzf-based selection or manual path entry), and image previews will display in a wider range of terminal environments, including those lacking inline image or sixel support. The code also refactors and extends terminal detection logic and preview fallbacks for robustness.

**New Features:**

* Added an interactive "open image" (`o` key) command, allowing users to open a new image at runtime using fzf for file selection, with a fallback to manual path entry if fzf is unavailable or canceled. (`main.go`, `fzf.go`) [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R26) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L55-R62) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R168-R198) [[4]](diffhunk://#diff-bb6b2db4242d1810f6d96453219e0e722d458679801b7de1da86cb9c661a9c59R38-R119)
* Implemented `SelectFileWithFzf` in `fzf.go`, which uses terminal detection to choose the best preview method in fzf, supporting kitty, iTerm2, sixel, or chafa previews. (`fzf.go`) [[1]](diffhunk://#diff-bb6b2db4242d1810f6d96453219e0e722d458679801b7de1da86cb9c661a9c59R6-R8) [[2]](diffhunk://#diff-bb6b2db4242d1810f6d96453219e0e722d458679801b7de1da86cb9c661a9c59R38-R119)

**Terminal Preview Improvements:**

* Added chafa as a fallback renderer for image previews, allowing previews in terminals that lack inline image or sixel support. This includes new detection logic (`hasChafa`), integration into the preview pipeline, and a `sendChafaPNG` helper. (`terminal_preview.go`) [[1]](diffhunk://#diff-4c32a70813f2af59375eb6db6f5922de99adfa6201dc1ff1a3bebf2eea8ee399R126-R156) [[2]](diffhunk://#diff-4c32a70813f2af59375eb6db6f5922de99adfa6201dc1ff1a3bebf2eea8ee399R209-R218) [[3]](diffhunk://#diff-4c32a70813f2af59375eb6db6f5922de99adfa6201dc1ff1a3bebf2eea8ee399R240-R249) [[4]](diffhunk://#diff-4c32a70813f2af59375eb6db6f5922de99adfa6201dc1ff1a3bebf2eea8ee399R259-R284) [[5]](diffhunk://#diff-4c32a70813f2af59375eb6db6f5922de99adfa6201dc1ff1a3bebf2eea8ee399L370-R431) [[6]](diffhunk://#diff-4c32a70813f2af59375eb6db6f5922de99adfa6201dc1ff1a3bebf2eea8ee399R456-R518)
* Updated documentation and debug output to reflect the new fallback logic and supported terminal types. (`terminal_preview.go`) [[1]](diffhunk://#diff-4c32a70813f2af59375eb6db6f5922de99adfa6201dc1ff1a3bebf2eea8ee399L30-R36) [[2]](diffhunk://#diff-4c32a70813f2af59375eb6db6f5922de99adfa6201dc1ff1a3bebf2eea8ee399L77-R83)

**Resource Management:**

* Improved wand (image handle) cleanup in `main.go` to ensure proper destruction and avoid leaks when opening new images.

These changes make the tool more user-friendly and robust, especially in diverse terminal environments.