### PR TITLE
Add interactive file selection using fzf, updates to input prompt logic, and cleanup of legacy code paths

### DIFF
--- a/internal/cli.go
+++ b/internal/cli.go
@@ -176,6 +176,8 @@ func RunCLI() {
 						lowerName := strings.ToLower(p.Name)
 						lowerHint := strings.ToLower(p.Hint)
 						if p.Type == ParamTypeString && (strings.Contains(lowerName, "path") || strings.Contains(lowerName, "file") || strings.Contains(lowerHint, "path") || strings.Contains(lowerHint, "file")) {
+							// Show the fzf hint only for file-like parameters.
+							prompt = fmt.Sprintf("%s (%s) [enter image path, url, or enter '/' to use fzf]: ", p.Name, typeLabel)
 							val, perr = PromptLineWithFzf(prompt)
 							if perr != nil {
 								fmt.Fprintf(os.Stderr, "input error: %v\n", perr)
@@ -227,7 +229,8 @@ func RunCLI() {
 					lowerName := strings.ToLower(param.Name)
 					// No ParamMeta.Hint available here in legacy path, so only inspect name.
 					if strings.Contains(lowerName, "path") || strings.Contains(lowerName, "file") {
-						// Use the same buffered reader to support single-key '/' detection.
+						// Add the fzf hint only for file-like params, then use the buffered reader helper.
+						prompt = fmt.Sprintf("Enter %s [Enter image path, url, or enter '/' to use fzf]: ", param.Name)
 						v, perr := PromptLineWithFzfReader(reader, prompt)
 						if perr != nil {
 							fmt.Fprintf(os.Stderr, "input error: %v\n", perr)

--- a/internal/cli.go
+++ b/internal/cli.go
@@ -218,44 +218,9 @@ func RunCLI() {
 				}
 			}
 
-			// Fallback legacy behavior: prompt using the simple CommandMeta.Params list and pass raw inputs.
-			rawArgs = make([]string, len(selectedCmd.Params))
-			for i, param := range selectedCmd.Params {
-				prompt := fmt.Sprintf("Enter %s: ", param.Name)
-
-				// Prefer PromptLineWithFzf for string params that look like file paths or filenames.
-				var val string
-				if param.Type == ParamTypeString {
-					lowerName := strings.ToLower(param.Name)
-					// No ParamMeta.Hint available here in legacy path, so only inspect name.
-					if strings.Contains(lowerName, "path") || strings.Contains(lowerName, "file") {
-						// Add the fzf hint only for file-like params, then use the buffered reader helper.
-						prompt = fmt.Sprintf("Enter %s [Enter image path, url, or enter '/' to use fzf]: ", param.Name)
-						v, perr := PromptLineWithFzfReader(reader, prompt)
-						if perr != nil {
-							fmt.Fprintf(os.Stderr, "input error: %v\n", perr)
-							v = ""
-						}
-						val = v
-						rawArgs[i] = val
-						continue
-					}
-				}
-
-				typed, _ := PromptLine(prompt)
-				rawArgs[i] = typed
-			}
-			if err := ApplyCommand(wand, commandName, rawArgs); err != nil {
-				fmt.Fprintf(os.Stderr, "apply command error: %v\n", err)
-				continue
-			}
-			fmt.Printf("Applied %s\n", commandName)
-			// Update inline terminal preview if available.
-			if err := PreviewWand(wand); err == nil {
-				if info, ierr := GetImageInfo(wand); ierr == nil {
-					fmt.Println(info)
-				}
-			}
+			// Metadata not found for this command (this should be unreachable with the current store).
+			fmt.Fprintf(os.Stderr, "metadata for command %s not found\n", commandName)
+			continue
 
 		case 's':
 			out, _ := PromptLine("Enter output filename: ")

--- a/internal/imagemagick.go
+++ b/internal/imagemagick.go
@@ -235,6 +235,7 @@ func ApplyCommand(wand *imagick.MagickWand, commandName string, args []string) e
 		}
 		sourceWand := imagick.NewMagickWand()
 		defer sourceWand.Destroy()
+		// Read source image into its own wand
 		if err := sourceWand.ReadImage(args[0]); err != nil {
 			return fmt.Errorf("failed to read source image: %w", err)
 		}

--- a/internal/update.go
+++ b/internal/update.go
@@ -132,8 +132,6 @@ func CheckForUpdates() error {
 	// Use the GitHub API fallback detector which is tolerant of tag naming.
 	latest, found, err := detectLatestFallback(repo)
 	fmt.Printf("Current version: %s\n", Version)
-	fmt.Printf("Checking for updates in %s...\n", repo)
-	fmt.Printf("Found release: %v\n", found)
 	if err != nil {
 		return fmt.Errorf("update check failed: %w", err)
 	}

--- a/internal/util.go
+++ b/internal/util.go
@@ -7,13 +7,81 @@ import (
 	"strings"
 )
 
-// PromptLine displays a prompt and reads a line of input from the user.
+// PromptLine displays a prompt and reads a full line of input from the user.
+// The returned string is trimmed of surrounding whitespace (including the newline).
 func PromptLine(prompt string) (string, error) {
 	fmt.Print(prompt)
 	reader := bufio.NewReader(os.Stdin)
-	text, err := reader.ReadString('\n')
+	line, err := reader.ReadString('\n')
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(text), nil
+	return strings.TrimSpace(line), nil
+}
+
+// PromptLineOrFzf reads a full line from stdin and treats a single-line "/"
+// as a request to invoke fzf for file selection. Behavior:
+//   - Print the prompt.
+//   - Read a full line (including spaces).
+//   - If the trimmed line equals "/", launch fzf via SelectFileWithFzf(".").
+//   - If fzf returns a non-empty selection, return it.
+//   - If fzf is unavailable or selection is cancelled, fall back to a typed prompt
+//     (re-using PromptLine to read a full line).
+//   - Otherwise return the trimmed line as the input value.
+//
+// This approach preserves support for paths containing spaces because we read
+// the entire input line instead of a single token.
+func PromptLineOrFzf(prompt string) (string, error) {
+	fmt.Print(prompt)
+	reader := bufio.NewReader(os.Stdin)
+
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	input := strings.TrimSpace(line)
+
+	if input == "/" {
+		// User requested fzf selection.
+		sel, selErr := SelectFileWithFzf(".")
+		if selErr == nil && sel != "" {
+			// Show concise indicator and return the selection.
+			fmt.Printf(" [fzf] %s\n", sel)
+			return sel, nil
+		}
+		// fzf not available or selection cancelled — fall back to typed prompt.
+		return PromptLine(prompt)
+	}
+
+	return input, nil
+}
+
+// PromptLineWithFzfReader is a convenience variant that reads from the provided
+// bufio.Reader. This is useful when the caller already has a reader instance
+// and wants to avoid creating a new one (ensures no input is lost to a
+// separate buffered reader).
+func PromptLineWithFzfReader(reader *bufio.Reader, prompt string) (string, error) {
+	fmt.Print(prompt)
+
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	input := strings.TrimSpace(line)
+
+	if input == "/" {
+		sel, selErr := SelectFileWithFzf(".")
+		if selErr == nil && sel != "" {
+			fmt.Printf(" [fzf] %s\n", sel)
+			return sel, nil
+		}
+		return PromptLine(prompt)
+	}
+	return input, nil
+}
+
+// PromptLineWithFzf kept for backward compatibility; it delegates to
+// PromptLineOrFzf (which reads the whole line and treats "/" as fzf trigger).
+func PromptLineWithFzf(prompt string) (string, error) {
+	return PromptLineOrFzf(prompt)
 }

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,3 +1,3 @@
 package internal
 
-var Version = "0.3.3"
+var Version = "0.4.0"


### PR DESCRIPTION
This pull request introduces several improvements to the CLI user experience, especially for commands that require file or path inputs, and refactors some legacy behaviors for better clarity and maintainability. The most notable changes are the addition of interactive file selection using fzf, updates to input prompt logic, and cleanup of legacy code paths.

### Enhanced CLI input experience

* File and path parameters in `RunCLI` now use `PromptLineWithFzf`, allowing users to type a path or press `/` to trigger fzf for interactive file selection. This makes it easier to select files and paths, especially in complex workflows.
* New helper functions added to `internal/util.go` (`PromptLineOrFzf`, `PromptLineWithFzfReader`, and updated `PromptLineWithFzf`) provide flexible and robust line reading and fzf integration, supporting spaces in paths and fallback behavior if fzf is unavailable.

### Refactoring and code cleanup

* Removed legacy fallback behavior in `RunCLI` for commands without metadata, replacing it with a clear error message when command metadata is missing. This simplifies the code and avoids ambiguous behavior.

### Minor improvements

* Added a clarifying comment in `ApplyCommand` to indicate that the source image is read into its own wand, improving code readability.
* Cleaned up update check output in `CheckForUpdates` by removing redundant logging, resulting in a more concise update message.
* Bumped the version number to `0.4.0` in `internal/version.go` to reflect these feature and usability improvements.